### PR TITLE
use water softener props when there is more than one device

### DIFF
--- a/apps/hydrolink.py
+++ b/apps/hydrolink.py
@@ -66,6 +66,9 @@ class HydroLinkStatus(hass.Hass):
 
         devices = r.json().get("data", [])
         for dev in devices:
+            if dev.get("system_type") != "demand_softener":
+                continue
+            
             props = dev.get("properties") or {}
             if not isinstance(props, dict):
                 self.error(f"`properties` is not dict! Got: {repr(props)}")


### PR DESCRIPTION
When a user has more than one Ecowater device (e.g. water softener and iron filter), use the correct properties for the water softener.